### PR TITLE
chore: group @voidzero-dev/vite-plus-core alias into the vite-plus group

### DIFF
--- a/shared.json
+++ b/shared.json
@@ -36,8 +36,9 @@
       "matchDatasources": ["ruby-version"]
     },
     {
+      "description": "Keep the whole Vite+ toolchain version in one PR: the `vp` pin in .tool-versions (github-releases voidzero-dev/vite-plus), the `vite-plus` npm devDep, and the `@voidzero-dev/vite-plus-core` package aliased by the `overrides.vite` entry. These are the same version expressed three ways; bumping them in separate PRs makes the standalone-vite/core Plugin types diverge (vp check TS2321/TS2769) and mismatches rolldown's native binding.",
       "groupName": "vite-plus",
-      "matchPackageNames": ["voidzero-dev/vite-plus", "vite-plus"]
+      "matchPackageNames": ["voidzero-dev/vite-plus", "vite-plus", "@voidzero-dev/vite-plus-core"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Problem

Consuming repos (e.g. `microfront`) alias `vite` to `@voidzero-dev/vite-plus-core` via `overrides.vite` — the officially documented Vite+ setup. Renovate tracks that alias as its own npm dependency (`@voidzero-dev/vite-plus-core`).

The existing `vite-plus` group only matched the `vp` `.tool-versions` pin (`voidzero-dev/vite-plus`) and the `vite-plus` npm devDep. The core alias therefore fell into `group:allNonMajor` and bumped in a **separate PR** from the CLI.

These are the **same version expressed three ways** and must move together. Splitting them makes the CLI/bundled half and the plugins' `vite`-peer half resolve two structurally divergent `Plugin` types, breaking CI:

- **lint (`vp check`)**: `TS2321` "Excessive stack depth comparing Plugin" / `TS2769`
- **test**: rolldown JS/native mismatch — `value "builtin:vite-wasm-fallback" does not match any variant of BindingBuiltinPluginName`

This just happened on `microfront` #202 (CLI bumped, alias stale) and #204 (alias bumped, CLI stale) — both red for the same reason.

## Fix

Add `@voidzero-dev/vite-plus-core` to the `vite-plus` group's `matchPackageNames` so all three land in one PR. No-op for repos that don't use the override.

Validated with `renovate-config-validator` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)